### PR TITLE
Simpler metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ node_modules
 .vscode
 .bloop
 metals.sbt
+.bsp
+
+bib

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HMLGamePlayer.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HMLGamePlayer.scala
@@ -157,8 +157,8 @@ class HMLGamePlayer[S, A, L] (
       f <- newFormulas
       cl = f.getRootClass()
       // privilege for failures and impossible futures
-      if (cl.height <= 1 && cl.negationLevels <= 1) || 
-        (cl.negationLevels == 1 && cl.maxNegationHeight == cl.height) ||
+      if (cl.observationHeight <= 1 && cl.negationLevels <= 1) || 
+        (cl.negationLevels == 1 && cl.maxNegationHeight == cl.observationHeight) ||
         !formulaClasses.exists(clOther => cl.above(clOther) && cl != clOther)
     } yield {
       f

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
@@ -26,9 +26,9 @@ object HennessyMilnerLogic {
       ObservationClass(
         obsClass.observationHeight,
         obsClass.conjunctionLevels + (if (!isPositive) 1 else 0),
-        obsClass.negationLevels,
         obsClass.maxPositiveDeepBranches,
         obsClass.maxPositiveBranches,
+        obsClass.negationLevels,
         obsClass.maxNegationHeight
       )
     }
@@ -78,12 +78,12 @@ object HennessyMilnerLogic {
           observationHeight = subterms.map(_.obsClass.observationHeight).max,
           /** the maximal amount of conjunctions when descending into a formula */
           conjunctionLevels = subterms.map(_.obsClass.conjunctionLevels).max + 1,
-          /** the maximal amount of negations when descending into a formula */
-          negationLevels = subterms.map(_.obsClass.negationLevels).max,
           /** the maximal amount of positive deep branches (observationHeight > 1)*/
           maxPositiveDeepBranches = (subterms.map(_.obsClass.maxPositiveDeepBranches) + (positiveSubterms.size - positiveFlatCount)).max,
           /** the maximal amount of positive branches */
           maxPositiveBranches = (subterms.map(_.obsClass.maxPositiveBranches) + positiveSubterms.size).max,
+          /** the maximal amount of negations when descending into a formula */
+          negationLevels = subterms.map(_.obsClass.negationLevels).max,
           /** maximal observationHeight of negative subformulas */
           maxNegationHeight = subterms.map(_.obsClass.maxNegationHeight).max
         )
@@ -116,7 +116,7 @@ object HennessyMilnerLogic {
     override val isPositive = false
 
     override val obsClass = ObservationClass(0, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),
-      andThen.obsClass.negationLevels + 1,0,0,andThen.obsClass.observationHeight) lub andThen.obsClass
+      0,0,andThen.obsClass.negationLevels + 1,andThen.obsClass.observationHeight) lub andThen.obsClass
 
   }
 

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
@@ -91,6 +91,8 @@ object HennessyMilnerLogic {
     }
   }
 
+  def True[A]: And[A] = And[A](Set())
+
   case class Observe[A](action: A, andThen: Formula[A]) extends Formula[A] {
     override def toString = "⟨" + action.toString + "⟩" + andThen.toString
 

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
@@ -29,8 +29,7 @@ object HennessyMilnerLogic {
         obsClass.negationLevels,
         obsClass.maxPositiveDeepBranches,
         obsClass.maxPositiveBranches,
-        obsClass.maxNegationHeight,
-        obsClass.nonNegativeConjuncts
+        obsClass.maxNegationHeight
       )
     }
 
@@ -70,7 +69,7 @@ object HennessyMilnerLogic {
     override val obsClass = {
       
       if (subterms.isEmpty) {
-        ObservationClass(0,0,0,0,0,0,false)
+        ObservationClass(0,0,0,0,0,0)
       } else {
         val positiveSubterms = subterms.filter(_.isPositive)
         val positiveFlatCount = positiveSubterms.count(_.obsClass.observationHeight <= 1)
@@ -86,8 +85,7 @@ object HennessyMilnerLogic {
           /** the maximal amount of positive branches */
           maxPositiveBranches = (subterms.map(_.obsClass.maxPositiveBranches) + positiveSubterms.size).max,
           /** maximal observationHeight of negative subformulas */
-          maxNegationHeight = subterms.map(_.obsClass.maxNegationHeight).max,
-          nonNegativeConjuncts = subterms.exists(f => f.isPositive || f.obsClass.nonNegativeConjuncts)
+          maxNegationHeight = subterms.map(_.obsClass.maxNegationHeight).max
         )
       }
     }
@@ -98,7 +96,8 @@ object HennessyMilnerLogic {
 
     override val isPositive = true
     
-    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),0,0,0,0, false) lub andThen.obsClass
+    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1,
+      andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),0,0,0,0) lub andThen.obsClass
 
   }
 
@@ -108,7 +107,7 @@ object HennessyMilnerLogic {
     //TODO: or andThen.isPositive ?
     override val isPositive = true
     
-    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1, andThen.obsClass.conjunctionLevels,0,0,0,0, false) lub andThen.obsClass
+    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1, andThen.obsClass.conjunctionLevels,0,0,0,0) lub andThen.obsClass
 
   }
   case class Negate[A](andThen: Formula[A]) extends Formula[A] {
@@ -116,7 +115,8 @@ object HennessyMilnerLogic {
 
     override val isPositive = false
 
-    override val obsClass = ObservationClass(0, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),andThen.obsClass.negationLevels + 1,0,0,andThen.obsClass.observationHeight,false) lub andThen.obsClass
+    override val obsClass = ObservationClass(0, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),
+      andThen.obsClass.negationLevels + 1,0,0,andThen.obsClass.observationHeight) lub andThen.obsClass
 
   }
 

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogic.scala
@@ -24,7 +24,7 @@ object HennessyMilnerLogic {
     /** class of this formula if it appears at the top level */
     def getRootClass() = {
       ObservationClass(
-        obsClass.height,
+        obsClass.observationHeight,
         obsClass.conjunctionLevels + (if (!isPositive) 1 else 0),
         obsClass.negationLevels,
         obsClass.maxPositiveDeepBranches,
@@ -72,7 +72,7 @@ object HennessyMilnerLogic {
       if (subterms.isEmpty) {
         ObservationClass(0,0,0,0,0,0,false)
       } else {
-        val (deepSubtermsPrelim, flatSubtermsPrelim) = subterms.partition(_.obsClass.height > 1)
+        val (deepSubtermsPrelim, flatSubtermsPrelim) = subterms.partition(_.obsClass.observationHeight > 1)
         val positiveFlat = flatSubtermsPrelim.find(_.isPositive)
         
         val (deepSubterms, flatSubterms) = if (deepSubtermsPrelim.isEmpty && positiveFlat.nonEmpty)
@@ -81,16 +81,16 @@ object HennessyMilnerLogic {
           (deepSubtermsPrelim, flatSubtermsPrelim)
 
         ObservationClass(
-          height = subterms.map(_.obsClass.height).max + 1,
+          observationHeight = subterms.map(_.obsClass.observationHeight).max,
           /** the maximal amount of conjunctions when descending into a formula */
           conjunctionLevels = subterms.map(_.obsClass.conjunctionLevels).max + 1,
           /** the maximal amount of negations when descending into a formula */
           negationLevels = subterms.map(_.obsClass.negationLevels).max,
           /** the maximal amount of positive deep branches */
           maxPositiveDeepBranches = (subterms.map(_.obsClass.maxPositiveDeepBranches) + deepSubtermsPrelim.count(_.isPositive)).max,
-          /** the maximal amount of positive flat branches (height > 1); if all branches are flat, one positive branch will be exempted from the count */
+          /** the maximal amount of positive flat branches (observationHeight > 1); if all branches are flat, one positive branch will be exempted from the count */
           maxPositiveFlatBranches = (subterms.map(_.obsClass.maxPositiveFlatBranches) + flatSubterms.count(f => f.isPositive)).max,
-          /** maximal height of negative subformulas */
+          /** maximal observationHeight of negative subformulas */
           maxNegationHeight = subterms.map(_.obsClass.maxNegationHeight).max,
           nonNegativeConjuncts = subterms.exists(f => f.isPositive || f.obsClass.nonNegativeConjuncts)
         )
@@ -103,7 +103,7 @@ object HennessyMilnerLogic {
 
     override val isPositive = true
     
-    override val obsClass = ObservationClass(andThen.obsClass.height + 1, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),0,0,0,0, false) lub andThen.obsClass
+    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),0,0,0,0, false) lub andThen.obsClass
 
   }
 
@@ -113,7 +113,7 @@ object HennessyMilnerLogic {
     //TODO: or andThen.isPositive ?
     override val isPositive = true
     
-    override val obsClass = ObservationClass(andThen.obsClass.height + 1, andThen.obsClass.conjunctionLevels,0,0,0,0, false) lub andThen.obsClass
+    override val obsClass = ObservationClass(andThen.obsClass.observationHeight + 1, andThen.obsClass.conjunctionLevels,0,0,0,0, false) lub andThen.obsClass
 
   }
   case class Negate[A](andThen: Formula[A]) extends Formula[A] {
@@ -121,7 +121,7 @@ object HennessyMilnerLogic {
 
     override val isPositive = false
 
-    override val obsClass = ObservationClass(0, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),andThen.obsClass.negationLevels + 1,0,0,andThen.obsClass.height,false) lub andThen.obsClass
+    override val obsClass = ObservationClass(0, andThen.obsClass.conjunctionLevels + (if (!andThen.isPositive) 1 else 0),andThen.obsClass.negationLevels + 1,0,0,andThen.obsClass.observationHeight,false) lub andThen.obsClass
 
   }
 

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
@@ -1,23 +1,23 @@
 package de.bbisping.eqfiddle.hml
 
 case class ObservationClass(
-  /** the maximal depth of the subformulas (⊤ has height 0, negation are neutral wrt. height) */
-  height: Int,
+  /** the maximal observation depth of the subformulas (⊤ has height 0, negation and conjunction are neutral wrt. height) */
+  observationHeight: Int,
   /** the maximal amount of conjunctions when descending into a formula */
   conjunctionLevels: Int,
   /** the maximal amount of negations when descending into a formula */
   negationLevels: Int,
   /** the maximal amount of positive deep branches */
   maxPositiveDeepBranches: Int,
-  /** the maximal amount of positive flat branches (height > 1); if all branches are flat, one positive branch will be counted as deep */
+  /** the maximal amount of positive flat branches (observationHeight > 1); if all branches are flat, one positive branch will be counted as deep */
   maxPositiveFlatBranches: Int,
-  /** maximal height of negative subformulas */
+  /** maximal observationHeight of negative subformulas */
   maxNegationHeight: Int,
   /** if there are any conjunctions with positive subformulas */
   nonNegativeConjuncts: Boolean
 ) {
   def lub(that: ObservationClass) = ObservationClass(
-    Integer.max(this.height, that.height),
+    Integer.max(this.observationHeight, that.observationHeight),
     Integer.max(this.conjunctionLevels, that.conjunctionLevels),
     Integer.max(this.negationLevels, that.negationLevels),
     Integer.max(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
@@ -27,7 +27,7 @@ case class ObservationClass(
   )
 
   def glb(that: ObservationClass) = ObservationClass(
-    Integer.min(this.height, that.height),
+    Integer.min(this.observationHeight, that.observationHeight),
     Integer.min(this.conjunctionLevels, that.conjunctionLevels),
     Integer.min(this.negationLevels, that.negationLevels),
     Integer.min(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
@@ -37,7 +37,7 @@ case class ObservationClass(
   )
 
   def above(that: ObservationClass) = (
-    this.height >= that.height &&
+    this.observationHeight >= that.observationHeight &&
     this.conjunctionLevels >= that.conjunctionLevels &&
     this.negationLevels >= that.negationLevels &&
     this.maxPositiveDeepBranches >= that.maxPositiveDeepBranches &&
@@ -49,7 +49,7 @@ case class ObservationClass(
   def strictlyAbove(that: ObservationClass) = (this != that) && (this above that)
 
   def below(that: ObservationClass) = (
-    this.height <= that.height &&
+    this.observationHeight <= that.observationHeight &&
     this.conjunctionLevels <= that.conjunctionLevels &&
     this.negationLevels <= that.negationLevels &&
     this.maxPositiveDeepBranches <= that.maxPositiveDeepBranches &&
@@ -64,7 +64,7 @@ case class ObservationClass(
 object ObservationClass {
   val INFTY = Integer.MAX_VALUE
 
-  // height, conjunctionLevels, negationLevels, maxPosDeep, maxNegDeep, maxPosFlat, maxNegH, nonNegConjs
+  // observationHeight, conjunctionLevels, negationLevels, maxPosDeep, maxNegDeep, maxPosFlat, maxNegH, nonNegConjs
   // nonNegConjs is necessary, because maxPosFlat will sometimes count one positive flat branch as deep to account for trace equivalences. 
   // The Linear-time Branching-time Spectrum
   val LTBTS = List(

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
@@ -12,9 +12,7 @@ case class ObservationClass(
   /** the maximal amount of positive branches*/
   maxPositiveBranches: Int,
   /** maximal observationHeight of negative subformulas */
-  maxNegationHeight: Int,
-  /** if there are any conjunctions with positive subformulas */
-  nonNegativeConjuncts: Boolean
+  maxNegationHeight: Int
 ) {
   def lub(that: ObservationClass) = ObservationClass(
     Integer.max(this.observationHeight, that.observationHeight),
@@ -22,8 +20,7 @@ case class ObservationClass(
     Integer.max(this.negationLevels, that.negationLevels),
     Integer.max(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
     Integer.max(this.maxPositiveBranches, that.maxPositiveBranches),
-    Integer.max(this.maxNegationHeight, that.maxNegationHeight),
-    this.nonNegativeConjuncts || that.nonNegativeConjuncts
+    Integer.max(this.maxNegationHeight, that.maxNegationHeight)
   )
 
   def glb(that: ObservationClass) = ObservationClass(
@@ -32,8 +29,7 @@ case class ObservationClass(
     Integer.min(this.negationLevels, that.negationLevels),
     Integer.min(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
     Integer.min(this.maxPositiveBranches, that.maxPositiveBranches),
-    Integer.min(this.maxNegationHeight, that.maxNegationHeight),
-    this.nonNegativeConjuncts && that.nonNegativeConjuncts
+    Integer.min(this.maxNegationHeight, that.maxNegationHeight)
   )
 
   def above(that: ObservationClass) = (
@@ -42,8 +38,7 @@ case class ObservationClass(
     this.negationLevels >= that.negationLevels &&
     this.maxPositiveDeepBranches >= that.maxPositiveDeepBranches &&
     this.maxPositiveBranches >= that.maxPositiveBranches &&
-    this.maxNegationHeight >= that.maxNegationHeight &&
-    (this.nonNegativeConjuncts || !that.nonNegativeConjuncts)
+    this.maxNegationHeight >= that.maxNegationHeight
   )
 
   def strictlyAbove(that: ObservationClass) = (this != that) && (this above that)
@@ -54,8 +49,7 @@ case class ObservationClass(
     this.negationLevels <= that.negationLevels &&
     this.maxPositiveDeepBranches <= that.maxPositiveDeepBranches &&
     this.maxPositiveBranches <= that.maxPositiveBranches &&
-    this.maxNegationHeight <= that.maxNegationHeight &&
-    (!this.nonNegativeConjuncts || that.nonNegativeConjuncts)
+    this.maxNegationHeight <= that.maxNegationHeight
   )
 
   def strictlyBelow(that: ObservationClass) = (this != that) && (this below that)
@@ -64,22 +58,21 @@ case class ObservationClass(
 object ObservationClass {
   val INFTY = Integer.MAX_VALUE
 
-  // observationHeight, conjunctionLevels, negationLevels, maxPosDeep, maxNegDeep, maxPosFlat, maxNegH, nonNegConjs
-  // nonNegConjs is necessary, because maxPosFlat will sometimes count one positive flat branch as deep to account for trace equivalences. 
+  // observationHeight, conjunctionLevels, negationLevels, maxPosDeep, maxPos, maxNegH
   // The Linear-time Branching-time Spectrum
   val LTBTS = List(
-    "enabledness" ->        ObservationClass(    1,     0,    0,    0,    0,    0,false),
-    "traces" ->             ObservationClass(INFTY,     0,    0,    0,    0,    0,false),
-    "failure" ->            ObservationClass(INFTY,     1,    1,    0,    0,    1,false),
-    "readiness" ->          ObservationClass(INFTY,     1,    1,    0,INFTY,    1,true),
-    "failure-trace" ->      ObservationClass(INFTY, INFTY,    1,    1,    1,    1,true),
-    "ready-trace" ->        ObservationClass(INFTY, INFTY,    1,    1,INFTY,    1,true),
-    "impossible-future" ->  ObservationClass(INFTY,     1,    1,    0,    0,INFTY,false),
-    "possible-future" ->    ObservationClass(INFTY,     1,    1,INFTY,INFTY,INFTY,true),
-    "simulation" ->         ObservationClass(INFTY, INFTY,    0,INFTY,INFTY,    0,true),
-    "ready-simulation" ->   ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,    1,true),
-    "2-nested-simulation"-> ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,INFTY,true),
-    "bisimulation" ->       ObservationClass(INFTY, INFTY,INFTY,INFTY,INFTY,INFTY,true)
+    "enabledness" ->        ObservationClass(    1,     0,    0,    0,    0,    0),
+    "traces" ->             ObservationClass(INFTY,     0,    0,    0,    0,    0),
+    "failure" ->            ObservationClass(INFTY,     1,    1,    0,    0,    1),
+    "readiness" ->          ObservationClass(INFTY,     1,    1,    0,INFTY,    1),
+    "failure-trace" ->      ObservationClass(INFTY, INFTY,    1,    1,    1,    1),
+    "ready-trace" ->        ObservationClass(INFTY, INFTY,    1,    1,INFTY,    1),
+    "impossible-future" ->  ObservationClass(INFTY,     1,    1,    0,    0,INFTY),
+    "possible-future" ->    ObservationClass(INFTY,     1,    1,INFTY,INFTY,INFTY),
+    "simulation" ->         ObservationClass(INFTY, INFTY,    0,INFTY,INFTY,    0),
+    "ready-simulation" ->   ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,    1),
+    "2-nested-simulation"-> ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,INFTY),
+    "bisimulation" ->       ObservationClass(INFTY, INFTY,INFTY,INFTY,INFTY,INFTY)
   )
 
   val LTBTSNotionNames = LTBTS.map(_._1).toSet

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
@@ -7,10 +7,10 @@ case class ObservationClass(
   conjunctionLevels: Int,
   /** the maximal amount of negations when descending into a formula */
   negationLevels: Int,
-  /** the maximal amount of positive deep branches */
+  /** the maximal amount of positive deep branches (observationHeight > 1)*/
   maxPositiveDeepBranches: Int,
-  /** the maximal amount of positive flat branches (observationHeight > 1); if all branches are flat, one positive branch will be counted as deep */
-  maxPositiveFlatBranches: Int,
+  /** the maximal amount of positive branches*/
+  maxPositiveBranches: Int,
   /** maximal observationHeight of negative subformulas */
   maxNegationHeight: Int,
   /** if there are any conjunctions with positive subformulas */
@@ -21,7 +21,7 @@ case class ObservationClass(
     Integer.max(this.conjunctionLevels, that.conjunctionLevels),
     Integer.max(this.negationLevels, that.negationLevels),
     Integer.max(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
-    Integer.max(this.maxPositiveFlatBranches, that.maxPositiveFlatBranches),
+    Integer.max(this.maxPositiveBranches, that.maxPositiveBranches),
     Integer.max(this.maxNegationHeight, that.maxNegationHeight),
     this.nonNegativeConjuncts || that.nonNegativeConjuncts
   )
@@ -31,7 +31,7 @@ case class ObservationClass(
     Integer.min(this.conjunctionLevels, that.conjunctionLevels),
     Integer.min(this.negationLevels, that.negationLevels),
     Integer.min(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
-    Integer.min(this.maxPositiveFlatBranches, that.maxPositiveFlatBranches),
+    Integer.min(this.maxPositiveBranches, that.maxPositiveBranches),
     Integer.min(this.maxNegationHeight, that.maxNegationHeight),
     this.nonNegativeConjuncts && that.nonNegativeConjuncts
   )
@@ -41,7 +41,7 @@ case class ObservationClass(
     this.conjunctionLevels >= that.conjunctionLevels &&
     this.negationLevels >= that.negationLevels &&
     this.maxPositiveDeepBranches >= that.maxPositiveDeepBranches &&
-    this.maxPositiveFlatBranches >= that.maxPositiveFlatBranches &&
+    this.maxPositiveBranches >= that.maxPositiveBranches &&
     this.maxNegationHeight >= that.maxNegationHeight &&
     (this.nonNegativeConjuncts || !that.nonNegativeConjuncts)
   )
@@ -53,7 +53,7 @@ case class ObservationClass(
     this.conjunctionLevels <= that.conjunctionLevels &&
     this.negationLevels <= that.negationLevels &&
     this.maxPositiveDeepBranches <= that.maxPositiveDeepBranches &&
-    this.maxPositiveFlatBranches <= that.maxPositiveFlatBranches &&
+    this.maxPositiveBranches <= that.maxPositiveBranches &&
     this.maxNegationHeight <= that.maxNegationHeight &&
     (!this.nonNegativeConjuncts || that.nonNegativeConjuncts)
   )
@@ -72,7 +72,7 @@ object ObservationClass {
     "traces" ->             ObservationClass(INFTY,     0,    0,    0,    0,    0,false),
     "failure" ->            ObservationClass(INFTY,     1,    1,    0,    0,    1,false),
     "readiness" ->          ObservationClass(INFTY,     1,    1,    0,INFTY,    1,true),
-    "failure-trace" ->      ObservationClass(INFTY, INFTY,    1,    1,    0,    1,true),
+    "failure-trace" ->      ObservationClass(INFTY, INFTY,    1,    1,    1,    1,true),
     "ready-trace" ->        ObservationClass(INFTY, INFTY,    1,    1,INFTY,    1,true),
     "impossible-future" ->  ObservationClass(INFTY,     1,    1,    0,    0,INFTY,false),
     "possible-future" ->    ObservationClass(INFTY,     1,    1,INFTY,INFTY,INFTY,true),

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
@@ -5,39 +5,39 @@ case class ObservationClass(
   observationHeight: Int,
   /** the maximal amount of conjunctions when descending into a formula */
   conjunctionLevels: Int,
-  /** the maximal amount of negations when descending into a formula */
-  negationLevels: Int,
   /** the maximal amount of positive deep branches (observationHeight > 1)*/
   maxPositiveDeepBranches: Int,
   /** the maximal amount of positive branches*/
   maxPositiveBranches: Int,
+  /** the maximal amount of negations when descending into a formula */
+  negationLevels: Int,
   /** maximal observationHeight of negative subformulas */
   maxNegationHeight: Int
 ) {
   def lub(that: ObservationClass) = ObservationClass(
     Integer.max(this.observationHeight, that.observationHeight),
     Integer.max(this.conjunctionLevels, that.conjunctionLevels),
-    Integer.max(this.negationLevels, that.negationLevels),
     Integer.max(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
     Integer.max(this.maxPositiveBranches, that.maxPositiveBranches),
+    Integer.max(this.negationLevels, that.negationLevels),
     Integer.max(this.maxNegationHeight, that.maxNegationHeight)
   )
 
   def glb(that: ObservationClass) = ObservationClass(
     Integer.min(this.observationHeight, that.observationHeight),
     Integer.min(this.conjunctionLevels, that.conjunctionLevels),
-    Integer.min(this.negationLevels, that.negationLevels),
     Integer.min(this.maxPositiveDeepBranches, that.maxPositiveDeepBranches),
     Integer.min(this.maxPositiveBranches, that.maxPositiveBranches),
+    Integer.min(this.negationLevels, that.negationLevels),
     Integer.min(this.maxNegationHeight, that.maxNegationHeight)
   )
 
   def above(that: ObservationClass) = (
     this.observationHeight >= that.observationHeight &&
     this.conjunctionLevels >= that.conjunctionLevels &&
-    this.negationLevels >= that.negationLevels &&
     this.maxPositiveDeepBranches >= that.maxPositiveDeepBranches &&
     this.maxPositiveBranches >= that.maxPositiveBranches &&
+    this.negationLevels >= that.negationLevels &&
     this.maxNegationHeight >= that.maxNegationHeight
   )
 
@@ -46,9 +46,9 @@ case class ObservationClass(
   def below(that: ObservationClass) = (
     this.observationHeight <= that.observationHeight &&
     this.conjunctionLevels <= that.conjunctionLevels &&
-    this.negationLevels <= that.negationLevels &&
     this.maxPositiveDeepBranches <= that.maxPositiveDeepBranches &&
     this.maxPositiveBranches <= that.maxPositiveBranches &&
+    this.negationLevels <= that.negationLevels &&
     this.maxNegationHeight <= that.maxNegationHeight
   )
 
@@ -58,20 +58,20 @@ case class ObservationClass(
 object ObservationClass {
   val INFTY = Integer.MAX_VALUE
 
-  // observationHeight, conjunctionLevels, negationLevels, maxPosDeep, maxPos, maxNegH
+  // observationHeight, conjunctionLevels, maxPosDeep, maxPos, negationLevels, maxNegH
   // The Linear-time Branching-time Spectrum
   val LTBTS = List(
     "enabledness" ->        ObservationClass(    1,     0,    0,    0,    0,    0),
     "traces" ->             ObservationClass(INFTY,     0,    0,    0,    0,    0),
-    "failure" ->            ObservationClass(INFTY,     1,    1,    0,    0,    1),
-    "readiness" ->          ObservationClass(INFTY,     1,    1,    0,INFTY,    1),
+    "failure" ->            ObservationClass(INFTY,     1,    0,    0,    1,    1),
+    "readiness" ->          ObservationClass(INFTY,     1,    0,INFTY,    1,    1),
     "failure-trace" ->      ObservationClass(INFTY, INFTY,    1,    1,    1,    1),
-    "ready-trace" ->        ObservationClass(INFTY, INFTY,    1,    1,INFTY,    1),
-    "impossible-future" ->  ObservationClass(INFTY,     1,    1,    0,    0,INFTY),
-    "possible-future" ->    ObservationClass(INFTY,     1,    1,INFTY,INFTY,INFTY),
-    "simulation" ->         ObservationClass(INFTY, INFTY,    0,INFTY,INFTY,    0),
-    "ready-simulation" ->   ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,    1),
-    "2-nested-simulation"-> ObservationClass(INFTY, INFTY,    1,INFTY,INFTY,INFTY),
+    "ready-trace" ->        ObservationClass(INFTY, INFTY,    1,INFTY,    1,    1),
+    "impossible-future" ->  ObservationClass(INFTY,     1,    0,    0,    1,INFTY),
+    "possible-future" ->    ObservationClass(INFTY,     1,INFTY,INFTY,    1,INFTY),
+    "simulation" ->         ObservationClass(INFTY, INFTY,INFTY,INFTY,    0,    0),
+    "ready-simulation" ->   ObservationClass(INFTY, INFTY,INFTY,INFTY,    1,    1),
+    "2-nested-simulation"-> ObservationClass(INFTY, INFTY,INFTY,INFTY,    1,INFTY),
     "bisimulation" ->       ObservationClass(INFTY, INFTY,INFTY,INFTY,INFTY,INFTY)
   )
 

--- a/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
+++ b/shared/src/main/scala-2.12/de/bbisping/eqfiddle/hml/ObservationClass.scala
@@ -68,6 +68,7 @@ object ObservationClass {
   // nonNegConjs is necessary, because maxPosFlat will sometimes count one positive flat branch as deep to account for trace equivalences. 
   // The Linear-time Branching-time Spectrum
   val LTBTS = List(
+    "enabledness" ->        ObservationClass(    1,     0,    0,    0,    0,    0,false),
     "traces" ->             ObservationClass(INFTY,     0,    0,    0,    0,    0,false),
     "failure" ->            ObservationClass(INFTY,     1,    1,    0,    0,    1,false),
     "readiness" ->          ObservationClass(INFTY,     1,    1,    0,INFTY,    1,true),

--- a/shared/src/test/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogicTests.scala
+++ b/shared/src/test/scala-2.12/de/bbisping/eqfiddle/hml/HennessyMilnerLogicTests.scala
@@ -1,0 +1,30 @@
+package de.bbisping.eqfiddle.hml
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should
+
+class HennessyMilnerLogicTests extends AnyFunSpec with should.Matchers  {
+
+  import HennessyMilnerLogic._
+
+  describe("The HML metric") {
+    val ob1 = Observe("a", True[String])
+    it(ob1 + " should have coordinates (1,0,0,0,0,0)") {
+      ob1.obsClass should equal (ObservationClass(1,0,0,0,0,0))
+    }
+    
+    val ob2 = Observe("a", Negate( Observe("a", True[String])))
+    it(ob2 + " should have coordinates (2,1,0,0,1,1)") {
+      ob2.obsClass should equal (ObservationClass(2,1,0,0,1,1))
+    }
+
+    val ob3 = Observe("a", And( Set[Formula[String]](
+      Negate( Observe("a", True[String])),
+      Observe("a", True[String]),
+      Observe("a", Observe("a", True[String]))
+    )))
+    it(ob3 + " should have coordinates (3,1,1,2,1,1)") {
+      ob3.obsClass should equal (ObservationClass(3,1,1,2,1,1))
+    }
+  }
+}


### PR DESCRIPTION
The metric is changed to count positive deep branches and positive branches in general.

Previously, flat positive branches were counted instead of the overall count of positive branches. This was complicated for failure trace equivalence where a flat branch may sometimes appear in the role of the one allowed “deep” positive branch. Also, there were other tricks needed in order to manage the ready/failure/trace diamond. These can be removed thanks to the new metric.

The PR also changes the observation height dimensions to line up with the paper and to add *enabledness* equivalence.

The dimensions of the metric are reordered to line up with the paper.