### PR TITLE
Split CSV lines in at most 2 places

### DIFF
--- a/shared/src/main/scala-2.12/io/equiv/eqfiddle/ts/CSVTSLoader.scala
+++ b/shared/src/main/scala-2.12/io/equiv/eqfiddle/ts/CSVTSLoader.scala
@@ -17,8 +17,13 @@ class CSVTSLoader(
     val relationTuples = new Queue[(Int, Symbol, Int)]()
     val bufferedSource = scala.io.Source.fromFile(tsFileName)
     for (line <- bufferedSource.getLines) {
-      val trans = line.split(",").map(_.trim)
-      relationTuples += (( trans(0).toInt, Symbol(trans(2)), trans(1).toInt ))
+      val firstComma = line.indexWhere(_ == ',', 0)
+      val secondComma = line.indexWhere(_ == ',', firstComma + 1)
+      val start = line.slice(0, firstComma).trim
+      val end = line.slice(firstComma + 1, secondComma).trim
+      val label = line.slice(secondComma + 1, line.size).trim
+
+      relationTuples += (( start.toInt, Symbol(label), end.toInt ))
     }
     bufferedSource.close
 


### PR DESCRIPTION
Previously, if a transition label contained a comma, the CSV loader would truncate the label there.
This causes the following lines to be considered as transitions with the same label of `"s4(d1"`:

```
66,98,"s4(d1,first)"
1636,1674,"s4(d1,last)"
```

The above transitions are found in the `cwi_1_2.csv` benchmark file. This issue caused only 9 enabledness-classes to be detected instead of 11.

This fix changes the behavior so that a line is split in at most 3 parts, everything after the second comma goes into the label.